### PR TITLE
Add missing env variable placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,37 @@
-# Binance API (не потрібні ключі для публічних даних)
+# General bot settings
+BOT_ENV=development        # Environment name (development/test/production)
+BINANCE_TESTNET=true       # Use Binance testnet when true
+
+# Binance API (public data)
 BINANCE_API_BASE_URL=https://api.binance.com
 
-# База даних
+# Database
 DB_PATH=./data/simulation.db
 
-# Параметри збору даних
-WORKERS_COUNT=10
-RATE_LIMIT_DELAY_MS=100
-RETRY_ATTEMPTS=3
+# Data collection settings
+WORKERS_COUNT=10           # Number of worker threads for collectors
+RATE_LIMIT_DELAY_MS=100    # Delay between API requests in ms
+RETRY_ATTEMPTS=3           # Number of API retry attempts
 
-# Параметри симуляції
-INITIAL_BALANCE_USDT=10000
-DEFAULT_BUY_AMOUNT_USDT=50
-DEFAULT_BINANCE_FEE_PERCENT=0.00075
+# Simulation / trading
+INITIAL_BALANCE_USDT=10000           # Starting USDT balance
+DEFAULT_BUY_AMOUNT_USDT=50           # Default position size for simulations
+DEFAULT_BINANCE_FEE_PERCENT=0.00075  # Binance fee used in calculations
 
-# Логування
-LOG_LEVEL=info
-LOG_FILE=./logs/simulator.log
+# Live trading parameters
+TAKE_PROFIT_PERCENT=2.0                # Take profit threshold
+STOP_LOSS_PERCENT=1.0                  # Stop loss threshold
+TRAILING_STOP_ENABLED=false            # Enable trailing stop loss
+TRAILING_STOP_PERCENT=0.5              # Trailing stop distance in percent
+TRAILING_STOP_ACTIVATION_PERCENT=1.0   # Profit level to activate trailing stop
+BUY_AMOUNT_USDT=100                    # Position size per trade
+MAX_OPEN_TRADES=3                      # Max simultaneous open trades
+MIN_LIQUIDITY_USDT=10000               # Minimum liquidity to enter trade
+MAX_PRICE_IMPACT=0.5                   # Max allowed price impact percent
+COOLDOWN_SECONDS=300                   # Cooldown between trades in seconds
+MAX_TRADE_TIME_MINUTES=15              # Max duration of a trade in minutes
+
+# Logging
+LOG_LEVEL=info                # Logger level (error, warn, info, debug)
+LOG_FILE=./logs/simulator.log # Path to log file
+


### PR DESCRIPTION
## Summary
- document full set of environment variables in `.env.example`

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687838ef7b4c832a859ea1e47013cb75