### PR TITLE
Fix fs import in optimizer

### DIFF
--- a/src/analysis/optimizer.js
+++ b/src/analysis/optimizer.js
@@ -1,6 +1,7 @@
 import { TradingSimulator } from './simulator.js';
 import { SimulationConfigModel } from '../database/models.js';
 import logger from '../utils/logger.js';
+import fs from 'fs';
 
 export class ParameterOptimizer {
   constructor() {
@@ -337,7 +338,6 @@ export class ParameterOptimizer {
       exportDate: new Date().toISOString()
     };
     
-    const fs = require('fs');
     fs.writeFileSync(filename, JSON.stringify(data, null, 2));
     logger.info(`Optimization results exported to ${filename}`);
   }


### PR DESCRIPTION
## Summary
- update optimizer to use ES module `fs` import

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68783912f188832a8db239baf20b9af9