### PR TITLE
Fix module import paths

### DIFF
--- a/src/analysis/optimizer.js
+++ b/src/analysis/optimizer.js
@@ -1,4 +1,4 @@
-import { TradingSimulator } from './simulator.js';
+import { TradingSimulator } from '../simulation/simulator.js';
 import { SimulationConfigModel } from '../database/models.js';
 import logger from '../utils/logger.js';
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,11 +18,10 @@ const __dirname = dirname(__filename);
 import logger from './utils/logger.js';
 import { validateEnvironmentVariables } from './utils/validators.js';
 import { getDatabase, initializeDatabase } from './database/init.js';
-import { runMigrations } from './database/migrate.js';
 import { TradingEngine } from './simulation/tradingEngine.js';
 import { TradingSimulator } from './simulation/simulator.js';
-import { ParameterOptimizer } from './simulation/optimizer.js';
-import { NewListingScalperStrategy } from './strategies/newListingScalper.js';
+import { ParameterOptimizer } from './analysis/optimizer.js';
+import { NewListingScalperStrategy } from './simulation/strategies/newListingScalper.js';
 
 // Глобальні змінні
 let tradingEngine = null;

--- a/src/simulation/simulator.js
+++ b/src/simulation/simulator.js
@@ -1,7 +1,7 @@
 import { getDatabase } from '../database/init.js';
 import { SymbolModel, SimulationResultModel, SimulationConfigModel } from '../database/models.js';
-import { NewListingScalperStrategy } from '../strategies/newListingScalper.js';
-import { TrailingStopLoss } from '../strategies/trailingStopLoss.js';
+import { NewListingScalperStrategy } from './strategies/newListingScalper.js';
+import { TrailingStopLoss } from './strategies/trailingStopLoss.js';
 import { validateConfig, validateMarketData } from '../utils/validators.js';
 import { calculateProfitLoss, calculateCommission, calculateLiquidity, calculateVolatility } from '../utils/calculations.js';
 import logger from '../utils/logger.js';

--- a/src/simulation/tradingEngine.js
+++ b/src/simulation/tradingEngine.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
-import { NewListingScalperStrategy } from '../strategies/newListingScalper.js';
-import { TrailingStopLoss } from '../strategies/trailingStopLoss.js';
+import { NewListingScalperStrategy } from './strategies/newListingScalper.js';
+import { TrailingStopLoss } from './strategies/trailingStopLoss.js';
 import { validateTrade, validateOrderBook, validateMarketData } from '../utils/validators.js';
 import { calculateProfitLoss, calculateCommission } from '../utils/calculations.js';
 import logger from '../utils/logger.js';


### PR DESCRIPTION
## Summary
- fix import paths for strategies and optimizer modules
- clean up unused runMigrations import

## Testing
- `node --check src/index.js`
- `node --check src/simulation/simulator.js`
- `node --check src/simulation/tradingEngine.js`
- `node --check src/analysis/optimizer.js`


------
https://chatgpt.com/codex/tasks/task_e_68783910f8bc832ab8bbfee1d5c77d51