### PR TITLE
Add simple test runner and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "collect": "node scripts/collect-data.js",
     "simulate": "node scripts/run-simulation.js",
     "analyze": "node scripts/analyze-results.js",
-    "db:init": "node src/database/init.js"
+    "db:init": "node src/database/init.js",
+    "test": "node test-runner.js"
   },
   "dependencies": {
     "better-sqlite3": "^9.2.2",

--- a/test-runner.js
+++ b/test-runner.js
@@ -1,0 +1,34 @@
+import { readdir } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+async function runTests() {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const testDir = path.join(__dirname, 'tests');
+  const files = await readdir(testDir);
+  let passed = 0;
+  let failed = 0;
+
+  for (const file of files.filter(f => f.endsWith('.test.js'))) {
+    const module = await import(path.join(testDir, file));
+    for (const [name, testFn] of Object.entries(module)) {
+      if (typeof testFn === 'function') {
+        try {
+          await testFn();
+          console.log(`\u2713 ${name}`);
+          passed++;
+        } catch (err) {
+          console.error(`\u2717 ${name}`);
+          console.error(err);
+          failed++;
+        }
+      }
+    }
+  }
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+runTests();

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import { parseTimeframe, average } from '../src/utils/helpers.js';
+
+export async function testParseTimeframe() {
+  assert.strictEqual(parseTimeframe('1m'), 60 * 1000);
+  assert.strictEqual(parseTimeframe('2h'), 2 * 60 * 60 * 1000);
+}
+
+export async function testAverage() {
+  assert.strictEqual(average([1, 2, 3]), 2);
+  assert.strictEqual(average([]), 0);
+}


### PR DESCRIPTION
## Summary
- add a minimal custom test framework `test-runner.js`
- create unit tests for helper functions
- expose a `test` script in `package.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687837b9d6c8832abbe07866140c8e60