### PR TITLE
Fix market data field names and add regression test

### DIFF
--- a/src/simulation/simulator.js
+++ b/src/simulation/simulator.js
@@ -212,8 +212,8 @@ export class TradingSimulator {
     try {
       // Отримання історичних klines
       const klinesQuery = `
-        SELECT open_time, close_time, open, high, low, close, volume, quote_volume
-        FROM historical_klines 
+        SELECT open_time, close_time, open_price, high_price, low_price, close_price, volume, quote_asset_volume
+        FROM historical_klines
         WHERE symbol_id = ? 
         AND open_time >= ? 
         AND open_time <= ?
@@ -235,13 +235,13 @@ export class TradingSimulator {
       const lastKline = klines[klines.length - 1];
       const ticker = {
         symbol,
-        price: lastKline.close,
+        price: lastKline.close_price,
         volume: lastKline.volume,
         priceChangePercent: this.calculatePriceChange(klines)
       };
       
       // Створення простого order book (симуляція)
-      const currentPrice = parseFloat(lastKline.close);
+      const currentPrice = parseFloat(lastKline.close_price);
       const orderBook = this.generateSimulatedOrderBook(currentPrice);
       
       return {
@@ -249,11 +249,12 @@ export class TradingSimulator {
         ticker,
         orderBook,
         klines: klines.map(k => ({
-          open: k.open,
-          high: k.high,
-          low: k.low,
-          close: k.close,
+          open_price: k.open_price,
+          high_price: k.high_price,
+          low_price: k.low_price,
+          close_price: k.close_price,
           volume: k.volume,
+          quote_asset_volume: k.quote_asset_volume,
           openTime: k.open_time,
           closeTime: k.close_time
         })),
@@ -274,8 +275,8 @@ export class TradingSimulator {
   calculatePriceChange(klines) {
     if (klines.length < 2) return '0.00';
     
-    const firstPrice = parseFloat(klines[0].open);
-    const lastPrice = parseFloat(klines[klines.length - 1].close);
+    const firstPrice = parseFloat(klines[0].open_price);
+    const lastPrice = parseFloat(klines[klines.length - 1].close_price);
     const change = ((lastPrice - firstPrice) / firstPrice) * 100;
     
     return change.toFixed(2);

--- a/tests/simulator.test.js
+++ b/tests/simulator.test.js
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import { getDatabase, closeDatabase } from '../src/database/init.js';
+import { TradingSimulator } from '../src/simulation/simulator.js';
+
+export async function testFetchKlinesDoesNotThrow() {
+  process.env.DB_PATH = ':memory:';
+  const db = await getDatabase();
+
+  const symbolId = 1;
+  const symbol = 'TESTUSDT';
+  const listingDate = Date.now();
+
+  const insert = `INSERT INTO historical_klines (
+    symbol_id, open_time, close_time, open_price, high_price, low_price,
+    close_price, volume, quote_asset_volume, number_of_trades,
+    taker_buy_base_asset_volume, taker_buy_quote_asset_volume
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+  for (let i = 0; i < 20; i++) {
+    const openTime = listingDate + i * 60_000;
+    const closeTime = openTime + 59_000;
+    await db.run(
+      insert,
+      symbolId,
+      openTime,
+      closeTime,
+      1 + i,
+      1.1 + i,
+      0.9 + i,
+      1.05 + i,
+      100 + i,
+      110 + i,
+      10,
+      50,
+      55
+    );
+  }
+
+  const sim = new TradingSimulator({
+    name: 'Test',
+    takeProfitPercent: 2,
+    stopLossPercent: 1,
+    buyAmountUsdt: 10,
+    maxOpenTrades: 1,
+    trailingStopEnabled: false
+  });
+
+  const data = await sim.getMarketDataForListing(symbolId, symbol, listingDate);
+  assert(data);
+
+  await closeDatabase();
+}


### PR DESCRIPTION
## Summary
- update DB column references in `getMarketDataForListing`
- use new field names in returned klines
- adjust `calculatePriceChange` for new names
- add regression test ensuring klines fetching works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797cedbecc832aba5cb40ffdc1969c