### PR TITLE
Ensure listing analysis rows are unique per symbol

### DIFF
--- a/scripts/migrate-listing-analysis-unique.js
+++ b/scripts/migrate-listing-analysis-unique.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { mkdirSync } from 'fs';
+
+async function migrate() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const dbDir = join(__dirname, '../data');
+  mkdirSync(dbDir, { recursive: true });
+  const dbPath = process.env.DB_PATH || join(dbDir, 'simulation.db');
+
+  const db = await open({ filename: dbPath, driver: sqlite3.Database });
+
+  await db.exec('PRAGMA journal_mode = WAL;');
+
+  const duplicates = await db.all(`
+    SELECT symbol_id
+    FROM listing_analysis
+    GROUP BY symbol_id
+    HAVING COUNT(*) > 1
+  `);
+
+  for (const row of duplicates) {
+    const keep = await db.get(
+      `SELECT id FROM listing_analysis
+       WHERE symbol_id = ?
+       ORDER BY analysis_date DESC, id DESC
+       LIMIT 1`,
+      row.symbol_id
+    );
+    await db.run(
+      `DELETE FROM listing_analysis
+       WHERE symbol_id = ? AND id != ?`,
+      row.symbol_id,
+      keep.id
+    );
+  }
+
+  await db.exec(
+    'CREATE UNIQUE INDEX IF NOT EXISTS idx_listing_analysis_symbol_unique ON listing_analysis(symbol_id)'
+  );
+
+  await db.close();
+  console.log('Migration completed.');
+}
+
+migrate().catch(err => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/src/collectors/listingAnalyzer.js
+++ b/src/collectors/listingAnalyzer.js
@@ -90,9 +90,14 @@ export class ListingAnalyzer {
   async saveListingAnalysis(symbolId, listingDate, status, errorMessage = null) {
     const db = await this.dbPromise;
     await db.run(
-      `INSERT OR REPLACE INTO listing_analysis
-       (symbol_id, listing_date, data_status, error_message, analysis_date)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT INTO listing_analysis (
+        symbol_id, listing_date, data_status, error_message, analysis_date
+      ) VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(symbol_id) DO UPDATE SET
+        listing_date = excluded.listing_date,
+        data_status = excluded.data_status,
+        error_message = excluded.error_message,
+        analysis_date = excluded.analysis_date`,
       symbolId,
       listingDate,
       status,

--- a/src/database/migrations.js
+++ b/src/database/migrations.js
@@ -28,10 +28,10 @@ export async function runMigrations(db) {
       error_message TEXT,
       analysis_date INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
       retry_count INTEGER DEFAULT 0,
-      FOREIGN KEY (symbol_id) REFERENCES symbols(id)
+      FOREIGN KEY (symbol_id) REFERENCES symbols(id),
+      UNIQUE(symbol_id)
     );
     
-    CREATE INDEX IF NOT EXISTS idx_listing_analysis_symbol ON listing_analysis(symbol_id);
     CREATE INDEX IF NOT EXISTS idx_listing_analysis_status ON listing_analysis(data_status);
     CREATE INDEX IF NOT EXISTS idx_listing_analysis_listing_date ON listing_analysis(listing_date);
     

--- a/tests/listingAnalysis.test.js
+++ b/tests/listingAnalysis.test.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { getDatabase, closeDatabase } from '../src/database/init.js';
+import { SymbolModel } from '../src/database/models.js';
+import { ListingAnalyzer } from '../src/collectors/listingAnalyzer.js';
+
+export async function testListingAnalysisUpsert() {
+  process.env.DB_PATH = ':memory:';
+  const db = await getDatabase();
+  const symbolModel = new SymbolModel();
+  const symbolId = await symbolModel.create({
+    symbol: 'TSTUSDT',
+    baseAsset: 'TST',
+    quoteAsset: 'USDT'
+  });
+
+  const analyzer = new ListingAnalyzer();
+  await analyzer.saveListingAnalysis(symbolId, 100, 'analyzed');
+  await db.run('UPDATE listing_analysis SET retry_count = 2 WHERE symbol_id = ?', symbolId);
+  await analyzer.saveListingAnalysis(symbolId, 200, 'error', 'fail');
+
+  const row = await db.get('SELECT * FROM listing_analysis WHERE symbol_id = ?', symbolId);
+  assert.strictEqual(row.listing_date, 200);
+  assert.strictEqual(row.data_status, 'error');
+  assert.strictEqual(row.retry_count, 2);
+
+  const count = (await db.get('SELECT COUNT(*) as c FROM listing_analysis')).c;
+  assert.strictEqual(count, 1);
+
+  await closeDatabase();
+}
+


### PR DESCRIPTION
## Summary
- enforce single listing_analysis row per symbol by adding UNIQUE constraint
- upsert listing analysis entries with `ON CONFLICT` so retry_count persists
- provide migration script for existing databases
- add regression test for new upsert behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687981f15c9c832abf051466655e9b82