### PR TITLE
Add DB busy timeout configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ BINANCE_API_BASE_URL=https://api.binance.com
 
 # Database
 DB_PATH=./data/simulation.db
+DB_BUSY_TIMEOUT_MS=5000
 
 # Data collection settings
 WORKERS_COUNT=10           # Number of worker threads for collectors

--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ DEFAULT_BUY_AMOUNT_USDT=50
 
 # Комісія Binance
 DEFAULT_BINANCE_FEE_PERCENT=0.00075
+
+# Таймаут очікування замкненої БД
+DB_BUSY_TIMEOUT_MS=5000
 ```
+
+Збільшення `DB_BUSY_TIMEOUT_MS` допомагає уникнути помилок `SQLITE_BUSY`, коли
+декілька воркерів одночасно зберігають klines.
 
 ### Логування
 

--- a/src/database/init.js
+++ b/src/database/init.js
@@ -17,6 +17,8 @@ export async function initializeDatabase() {
 
     const db = await open({ filename: dbPath, driver: sqlite3.Database });
 
+    await db.configure('busyTimeout', parseInt(process.env.DB_BUSY_TIMEOUT_MS) || 5000);
+
     await db.exec('PRAGMA journal_mode = WAL;');
     await db.exec('PRAGMA synchronous = NORMAL;');
     await db.exec('PRAGMA cache_size = 10000;');


### PR DESCRIPTION
## Summary
- configure SQLite `busyTimeout` in database init
- provide `DB_BUSY_TIMEOUT_MS` in `.env.example`
- document new variable and its impact on avoiding `SQLITE_BUSY` errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798996fc70832ab5340503c76e45ed