### PR TITLE
Validate trailing stop activation vs take profit

### DIFF
--- a/src/simulation/configGenerator.js
+++ b/src/simulation/configGenerator.js
@@ -42,6 +42,9 @@ export class ConfigurationGenerator {
         
         for (const amount of variations.buyAmountUsdt) {
           for (const trailing of variations.trailingStop) {
+            if (trailing.enabled && trailing.activation >= tp) {
+              continue;
+            }
             const config = {
               ...baseParams,
               takeProfitPercent: tp,

--- a/tests/configGenerator.test.js
+++ b/tests/configGenerator.test.js
@@ -16,3 +16,16 @@ export async function testGetConfigurationsCamelCase() {
   assert.strictEqual(typeof cfg.maxOpenTrades, 'number');
   await closeDatabase();
 }
+
+export async function testTrailingActivationBelowTP() {
+  process.env.DB_PATH = ':memory:';
+  await getDatabase();
+  const generator = new ConfigurationGenerator();
+  const configs = await generator.generateConfigurations();
+  for (const cfg of configs) {
+    if (cfg.trailingStopEnabled) {
+      assert(cfg.trailingStopActivationPercent < cfg.takeProfitPercent);
+    }
+  }
+  await closeDatabase();
+}


### PR DESCRIPTION
## Summary
- skip invalid trailing stop configs when activation >= TP
- test ConfigurationGenerator camelCase properties
- test trailing stop activation vs take-profit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687abea0962c832ab04f6ccec58d07fc