### PR TITLE
Fix kline field names

### DIFF
--- a/src/simulation/simulator.js
+++ b/src/simulation/simulator.js
@@ -252,12 +252,12 @@ async saveConfiguration() {
         ticker,
         orderBook,
         klines: klines.map(k => ({
-          open_price: k.open_price,
-          high_price: k.high_price,
-          low_price: k.low_price,
-          close_price: k.close_price,
+          open: k.open_price,
+          high: k.high_price,
+          low: k.low_price,
+          close: k.close_price,
           volume: k.volume,
-          quote_asset_volume: k.quote_asset_volume,
+          quoteAssetVolume: k.quote_asset_volume,
           openTime: k.open_time,
           closeTime: k.close_time
         })),
@@ -278,8 +278,8 @@ async saveConfiguration() {
   calculatePriceChange(klines) {
     if (klines.length < 2) return '0.00';
     
-    const firstPrice = parseFloat(klines[0].open_price);
-    const lastPrice = parseFloat(klines[klines.length - 1].close_price);
+    const firstPrice = parseFloat(klines[0].open);
+    const lastPrice = parseFloat(klines[klines.length - 1].close);
     const change = ((lastPrice - firstPrice) / firstPrice) * 100;
     
     return change.toFixed(2);

--- a/tests/simulator.test.js
+++ b/tests/simulator.test.js
@@ -47,6 +47,12 @@ export async function testFetchKlinesDoesNotThrow() {
 
   const data = await sim.getMarketDataForListing(symbolId, symbol, listingDate);
   assert(data);
+  const first = data.klines[0];
+  assert('open' in first);
+  assert('high' in first);
+  assert('low' in first);
+  assert('close' in first);
+  assert('quoteAssetVolume' in first);
 
   await closeDatabase();
 }


### PR DESCRIPTION
## Summary
- map DB kline columns to camelCase fields when returning market data
- adjust price change calculation to read the new kline field names
- verify returned kline field names in simulator tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4a8744d8832a98aae41a195a8124