### PR TITLE
Use decimal percents for newListingScalper

### DIFF
--- a/src/simulation/strategies/newListingScalper.js
+++ b/src/simulation/strategies/newListingScalper.js
@@ -354,9 +354,9 @@ export class NewListingScalperStrategy extends BaseStrategy {
    * Отримання умов виходу
    */
   getExitConditions(entryPrice, config) {
-    const takeProfitPrice = entryPrice * (1 + config.takeProfitPercent / 100);
-    const stopLossPrice = entryPrice * (1 - config.stopLossPercent / 100);
-    const trailingStopActivationPrice = entryPrice * (1 + config.trailingStopActivationPercent / 100);
+    const takeProfitPrice = entryPrice * (1 + config.takeProfitPercent);
+    const stopLossPrice = entryPrice * (1 - config.stopLossPercent);
+    const trailingStopActivationPrice = entryPrice * (1 + config.trailingStopActivationPercent);
 
     return {
       takeProfitPrice,

--- a/tests/simulator.test.js
+++ b/tests/simulator.test.js
@@ -38,8 +38,8 @@ export async function testFetchKlinesDoesNotThrow() {
 
   const sim = new TradingSimulator({
     name: 'Test',
-    takeProfitPercent: 2,
-    stopLossPercent: 1,
+    takeProfitPercent: 0.02,
+    stopLossPercent: 0.01,
     buyAmountUsdt: 10,
     maxOpenTrades: 1,
     trailingStopEnabled: false
@@ -63,8 +63,8 @@ export async function testSaveSimulationSummaryInsertsRow() {
 
   const sim = new TradingSimulator({
     name: 'Test',
-    takeProfitPercent: 2,
-    stopLossPercent: 1,
+    takeProfitPercent: 0.02,
+    stopLossPercent: 0.01,
     buyAmountUsdt: 10,
     maxOpenTrades: 1,
     trailingStopEnabled: false
@@ -104,8 +104,8 @@ export async function testTrailingStopSavesResult() {
 
   const sim = new TradingSimulator({
     name: 'TrailingTest',
-    takeProfitPercent: 30,
-    stopLossPercent: 5,
+    takeProfitPercent: 0.30,
+    stopLossPercent: 0.05,
     buyAmountUsdt: 10,
     maxOpenTrades: 1,
     trailingStopEnabled: true,


### PR DESCRIPTION
## Summary
- stop converting percent configs in `newListingScalper.getExitConditions`
- pass decimal percent values to simulator tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4b9626d4832aa4530802599cf85b