### PR TITLE
Update Binance fee examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ RETRY_ATTEMPTS=3           # Number of API retry attempts
 # Simulation / trading
 INITIAL_BALANCE_USDT=10000           # Starting USDT balance
 DEFAULT_BUY_AMOUNT_USDT=50           # Default position size for simulations
-DEFAULT_BINANCE_FEE_PERCENT=0.00075  # Binance fee used in calculations
+DEFAULT_BINANCE_FEE_PERCENT=0.075    # Binance fee percent used in calculations
 
 # Live trading parameters
 TAKE_PROFIT_PERCENT=2.0                # Take profit threshold

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ INITIAL_BALANCE_USDT=10000
 # Розмір позиції за замовчуванням
 DEFAULT_BUY_AMOUNT_USDT=50
 
-# Комісія Binance
-DEFAULT_BINANCE_FEE_PERCENT=0.00075
+# Комісія Binance (в %)
+DEFAULT_BINANCE_FEE_PERCENT=0.075
 
 # Таймаут очікування замкненої БД
 DB_BUSY_TIMEOUT_MS=5000

--- a/src/simulation/configGenerator.js
+++ b/src/simulation/configGenerator.js
@@ -16,7 +16,7 @@ export class ConfigurationGenerator {
     const baseParams = {
       maxOpenTrades: 3,
       minLiquidityUsdt: 10000,
-      binanceFeePercent: 0.00075,
+      binanceFeePercent: 0.075, // Binance trading fee percent
       cooldownSeconds: 3600
     };
     


### PR DESCRIPTION
## Summary
- set sample `DEFAULT_BINANCE_FEE_PERCENT` to `0.075`
- note percent unit in README and env example
- tweak config generator default fee percent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4c788db8832a89b7a18ff3ec0e09