### PR TITLE
Initialize skipReasonCounts on reset

### DIFF
--- a/src/simulation/simulator.js
+++ b/src/simulation/simulator.js
@@ -854,6 +854,7 @@ async saveConfiguration() {
     this.startTime = Date.now();
     this.processedListings = 0;
     this.skippedListings = 0;
+    this.skipReasonCounts = {};
   }
 }
 


### PR DESCRIPTION
## Summary
- reset `skipReasonCounts` map at the start of each simulation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d51469220832a9bb8dca0b80d622f