### PR TITLE
Use onboardDate when determining listing date

### DIFF
--- a/src/api/binanceClient.js
+++ b/src/api/binanceClient.js
@@ -259,7 +259,17 @@ class BinanceClient {
    * Отримання інформації про біржу
    */
   async getExchangeInfo() {
-    return await this.request('/api/v3/exchangeInfo');
+    const info = await this.request('/api/v3/exchangeInfo');
+
+    // Normalize onboardDate so it is always a number
+    if (info && Array.isArray(info.symbols)) {
+      info.symbols = info.symbols.map(sym => ({
+        ...sym,
+        onboardDate: sym.onboardDate ? Number(sym.onboardDate) : 0
+      }));
+    }
+
+    return info;
   }
   
   /**

--- a/src/collectors/listingAnalyzer.js
+++ b/src/collectors/listingAnalyzer.js
@@ -65,7 +65,21 @@ export class ListingAnalyzer {
   
   async determineListingDate(symbol) {
     logger.debug(`Determining precise listing date for ${symbol.symbol}`);
-    
+
+    // Try to obtain listing info directly from exchange metadata
+    try {
+      const exchangeInfo = await this.binanceClient.getExchangeInfo();
+      if (exchangeInfo && Array.isArray(exchangeInfo.symbols)) {
+        const meta = exchangeInfo.symbols.find(s => s.symbol === symbol.symbol);
+        if (meta && meta.onboardDate && meta.onboardDate !== 0) {
+          logger.info(`${symbol.symbol} onboard date found in exchange info`);
+          return meta.onboardDate;
+        }
+      }
+    } catch (err) {
+      logger.debug(`Could not get exchange info for ${symbol.symbol}: ${err.message}`);
+    }
+
     // Спочатку отримуємо денні свічки за останні 2 роки для широкого пошуку
     const twoYearsAgo = Date.now() - (2 * 365 * 24 * 60 * 60 * 1000);
     

--- a/tests/listingAnalysis.test.js
+++ b/tests/listingAnalysis.test.js
@@ -57,3 +57,22 @@ export async function testListingAnalysisModelCreateUpsert() {
   await closeDatabase();
 }
 
+export async function testDetermineListingDateUsesOnboardDate() {
+  const analyzer = new ListingAnalyzer();
+  let klinesCalled = false;
+
+  analyzer.binanceClient = {
+    async getExchangeInfo() {
+      return { symbols: [{ symbol: 'AAAUSDT', onboardDate: 987654321 }] };
+    },
+    async getKlines() {
+      klinesCalled = true;
+      return [];
+    }
+  };
+
+  const ts = await analyzer.determineListingDate({ symbol: 'AAAUSDT' });
+  assert.strictEqual(ts, 987654321);
+  assert.strictEqual(klinesCalled, false);
+}
+


### PR DESCRIPTION
## Summary
- normalize `onboardDate` when fetching exchange info
- use onboard date before falling back to kline heuristics
- test that onboard date is persisted by the listing analyzer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7cacaf9c832a820b96cda5117542