### PR TITLE
Fix kline pagination logic

### DIFF
--- a/src/api/binanceClient.js
+++ b/src/api/binanceClient.js
@@ -355,15 +355,22 @@ class BinanceClient {
           break;
         }
         
-        // Уникаємо дублювання останньої свічки при пагінації
-        const klinesToAdd = klines.length === MAX_KLINES ? 
-          klines.slice(0, -1) : klines;
-        
-        allKlines.push(...klinesToAdd);
-        
-        // Наступний batch
         const lastKline = klines[klines.length - 1];
-        currentStartTime = lastKline[6] + 1; // closeTime + 1ms
+        const nextStartTime = lastKline[6] + 1; // closeTime + 1ms
+
+        // Уникаємо дублювання останньої свічки при пагінації,
+        // але відкидаємо її лише якщо наступний batch дійсно перекривається
+        let klinesToAdd = klines;
+        if (klines.length === MAX_KLINES && nextStartTime <= endTime) {
+          if (nextStartTime <= lastKline[0]) {
+            klinesToAdd = klines.slice(0, -1);
+          }
+        }
+
+        allKlines.push(...klinesToAdd);
+
+        // Наступний batch
+        currentStartTime = nextStartTime;
         
         // Логування прогресу
         if (iterations % 10 === 0) {

--- a/tests/binanceClient.test.js
+++ b/tests/binanceClient.test.js
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import { getBinanceClient } from '../src/api/binanceClient.js';
+
+export async function testHistoricalKlinesHandlesPagination() {
+  const client = getBinanceClient();
+  const original = client.getKlines.bind(client);
+  const start = Date.now();
+  const total = 2880; // 48 hours of 1m klines
+
+  const klines = [];
+  for (let i = 0; i < total; i++) {
+    const open = start + i * 60_000;
+    const close = open + 59_000;
+    klines.push([open, '1', '1', '1', '1', '1', close, '1', '1', '1', '1']);
+  }
+
+  let callCount = 0;
+  client.getKlines = async (symbol, interval, startTime, endTime, limit) => {
+    callCount++;
+    const res = [];
+    for (const k of klines) {
+      if (k[0] >= startTime && k[0] <= endTime) {
+        res.push(k);
+        if (res.length >= limit) break;
+      }
+    }
+    return res;
+  };
+
+  const end = start + total * 60_000;
+  const result = await client.getHistoricalKlines('TEST', '1m', start, end);
+
+  assert.strictEqual(result.length, total);
+  assert(callCount > 1);
+
+  client.getKlines = original;
+}


### PR DESCRIPTION
## Summary
- refine kline pagination in Binance client to only drop when overlap occurs
- ensure 48h collection gets full data by adding regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7f33c5a8832a9b8cbd1c36c22a2d