### PR TITLE
Handle API error responses

### DIFF
--- a/src/api/binanceClient.js
+++ b/src/api/binanceClient.js
@@ -211,12 +211,25 @@ class BinanceClient {
         const startTime = Date.now();
         const response = await this.axios.get(endpoint, { params });
         const duration = Date.now() - startTime;
-        
+
+        if (response.status >= 400) {
+          const errorInfo = this.parseApiError({ response });
+          this.logApiError(errorInfo, {
+            endpoint,
+            params: Object.keys(params),
+            attempt,
+            requestId
+          });
+          const err = new Error(`API Error (${errorInfo.code}): ${errorInfo.message}`);
+          err.response = response;
+          throw err;
+        }
+
         logger.debug(`[${requestId}] Success (${duration}ms)`, {
           status: response.status,
           dataSize: Array.isArray(response.data) ? response.data.length : typeof response.data
         });
-        
+
         return response.data;
         
       } catch (error) {

--- a/tests/binanceClient.test.js
+++ b/tests/binanceClient.test.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import client from '../src/api/binanceClient.js';
+
+export async function testRequestThrowsOn400() {
+  const originalGet = client.axios.get;
+  client.axios.get = async () => ({
+    status: 400,
+    data: { code: -1102, msg: 'Bad request' },
+    headers: {}
+  });
+
+  try {
+    await assert.rejects(
+      client.request('/api/test'),
+      /Bad request/
+    );
+  } finally {
+    client.axios.get = originalGet;
+  }
+}


### PR DESCRIPTION
## Summary
- log and throw for HTTP error statuses in `request()` so retry logic kicks in
- add test covering a 400 response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f8cc425d0832a97e863d5d0d70bfd