### PR TITLE
Fix balance accounting for entry commission

### DIFF
--- a/src/simulation/tradingEngine.js
+++ b/src/simulation/tradingEngine.js
@@ -183,20 +183,25 @@ export class TradingEngine extends EventEmitter {
 
       if (order.success) {
         // Створення торгової позиції
+        const entryCommission = calculateCommission(
+          this.config.buyAmountUsdt,
+          this.config.binanceFeePercent
+        );
+
         const trade = this.createTrade({
           symbol,
           entryPrice: currentPrice,
           quantity,
           entryTime: Date.now(),
           orderId: order.orderId,
-          commission: calculateCommission(this.config.buyAmountUsdt, this.config.binanceFeePercent)
+          commission: entryCommission
         });
 
         // Додавання в активні угоди
         this.activeTrades.set(symbol, trade);
         
-        // Оновлення балансу
-        this.updateBalance(-this.config.buyAmountUsdt);
+        // Оновлення балансу (вартість покупки + комісія)
+        this.updateBalance(-(this.config.buyAmountUsdt + entryCommission));
         
         this.emit('trade_opened', trade);
         

--- a/tests/tradingEngineBalance.test.js
+++ b/tests/tradingEngineBalance.test.js
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import { TradingEngine } from '../src/simulation/tradingEngine.js';
+
+export async function testTradeProfitMatchesBalance() {
+  process.env.INITIAL_BALANCE_USDT = '10000';
+
+  const config = {
+    simulationMode: true,
+    buyAmountUsdt: 100,
+    binanceFeePercent: 0.1,
+    takeProfitPercent: 0.1,
+    stopLossPercent: 0.05
+  };
+
+  const apiClient = {
+    order: async () => ({ success: true, orderId: '1', price: 0, quantity: 1 }),
+    ping: async () => {},
+    balance: async () => ({ balances: [] })
+  };
+
+  const engine = new TradingEngine(config, apiClient);
+
+  // override order creation to bypass validation logic
+  engine.createOrder = async () => ({
+    success: true,
+    orderId: '1',
+    price: 0,
+    quantity: 1
+  });
+
+  // stub exit condition generator
+  engine.strategy.getExitConditions = (entryPrice, cfg) => ({
+    trailingStopEnabled: false,
+    takeProfitPrice: entryPrice * (1 + cfg.takeProfitPercent),
+    stopLossPrice: entryPrice * (1 - cfg.stopLossPercent)
+  });
+
+  const marketData = {
+    symbol: 'TSTUSDT',
+    ticker: { price: '100', volume: '1000', priceChangePercent: '0' },
+    orderBook: { bids: [['99', '1']], asks: [['101', '1']] },
+    klines: [{ open: '100', high: '100', low: '100', close: '100', volume: '1000' }]
+  };
+
+  const result = await engine.executeBuy(marketData);
+  assert(result.success);
+  const trade = result.trade;
+
+  // after buy, balance reduced by cost + commission
+  const afterBuy = 10000 - config.buyAmountUsdt - trade.commission;
+  assert.strictEqual(Number(engine.balance.usdt.toFixed(2)), Number(afterBuy.toFixed(2)));
+
+  await engine.closeTrade(trade, 'manual_close', 110);
+  const finalBalance = engine.balance.usdt;
+  const balanceDiff = finalBalance - 10000;
+  assert.strictEqual(balanceDiff.toFixed(2), trade.profitLossUsdt.toFixed(2));
+}


### PR DESCRIPTION
## Summary
- subtract entry commission when updating balance on buy
- test round trip balance against recorded P&L

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb2ea9988832ab8038063bd60a5ea